### PR TITLE
Fix readme, bump version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.1](https://github.com/crowbar/crowbar-validate-databags/releases/tag/v1.0.1) - 26-10-2018 
+
+* BUGFIX
+  * Fix readme instructions to clear up the release process (@itxaka)
+  * Fix homepage url (@itxaka)
+
 ## [1.0.0](https://github.com/crowbar/crowbar-validate-databags/releases/tag/v1.0.0) - 23-10-2018
 
 * Initial release (@itxaka)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,19 @@ versions) and for raising the version number, you can find the version in
 `lib/crowbar/validate/databags/version.rb`.
  
 After merging the pull request it's time to build the rubygem and to release it.
-This is done automatically by Travis once a tag is pushed.
+This is done automatically by Travis once a git tag is pushed or you can manually run `bundle exec rake release`
+on the master branch in order to create the tag (according to `lib/crowbar/validate/databags/version.rb`) 
+and push the gem at the same time.
 
-Last, go to https://github.com/crowbar/crowbar-validate-databags/releases/new and select
-the pushed tag. Then you should put the latest changelog into the description
+```
+$ bundle exec rake release
+crowbar-validate-databags 1.0.0 built to pkg/crowbar-validate-databags-1.0.0.gem.
+Tagged v1.0.0.
+Pushed git commits and tags.
+Pushed crowbar-validate-databags 1.0.0 to rubygems.org
+```
+
+
+Last, go to https://github.com/crowbar/crowbar-validate-databags/releases and edit the new release.
+Then you should put the latest changelog into the description
 form field.

--- a/crowbar-validate-databags.gemspec
+++ b/crowbar-validate-databags.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["igarcia@suse.com", "rsalevsky@suse.com"]
 
   spec.summary       = %q{Validates databags of crowbar.}
-  spec.homepage      = "http://github.com/itxaka/crowbar-validate-databags"
+  spec.homepage      = "http://github.com/crowbar/crowbar-validate-databags"
   spec.license       = "GPL-2.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|

--- a/lib/crowbar/validate/databags/version.rb
+++ b/lib/crowbar/validate/databags/version.rb
@@ -1,7 +1,7 @@
 module Crowbar
   module Validate
     module Databags
-      VERSION = "1.0.0"
+      VERSION = "1.0.1"
     end
   end
 end


### PR DESCRIPTION
Fix readme to be more clear on the release workflow
Fix homepage url pointing to the wrong url
Bump version to 1.0.1